### PR TITLE
fix(#55, EIDOMNI-306): Use correct image in sample.compose.yml

### DIFF
--- a/sample.compose.yml
+++ b/sample.compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 5s
       retries: 5
   verifier-service:
-    image: ghcr.io/swiyu-admin-ch/swiyu-verifier-service:latest
+    image: ghcr.io/swiyu-admin-ch/swiyu-verifier:latest
     configs:
       - source: verifier_metadata
         target: /verifier_metadata.json


### PR DESCRIPTION
As reporated in #55, we did not update the sample.compose.yml to this repository image.

Thanks to @tschortsch for reporting it.