### PR TITLE
fix(EIDOMNI-439): Add EC key parsing via map

### DIFF
--- a/verifier-application/src/main/java/ch/admin/bj/swiyu/verifier/infrastructure/health/SigningKeyVerificationHealthChecker.java
+++ b/verifier-application/src/main/java/ch/admin/bj/swiyu/verifier/infrastructure/health/SigningKeyVerificationHealthChecker.java
@@ -21,6 +21,8 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Health checker that validates the signing capability of the configured verification method.
@@ -139,10 +141,15 @@ public class SigningKeyVerificationHealthChecker extends CachedHealthChecker {
     private boolean verifySignature(SignedJWT signedJwt, DidDoc didDoc, String verificationMethod)
             throws JOSEException, DidSidekicksException, ParseException {        // Extract the JWK from the DID document
         Jwk jwk = didDoc.getKey(verificationMethod);
-
-        // Parse and convert to EC public key
-        JWK publicKey = JWK.parse(jwk.toString()).toECKey();
-
+        
+        final Map<String, Object> map = new HashMap<>();
+        map.put("kty", jwk.getKty());
+        map.put("crv", jwk.getCrv());
+        map.put("x", jwk.getX());
+        map.put("y", jwk.getY());
+        map.put("kid", jwk.getKid());
+        // Convert to EC public key
+        JWK publicKey = JWK.parse(map).toECKey();
         // Create verifier and verify signature
         JWSVerifier verifier = new ECDSAVerifier(publicKey.toECKey());
         return signedJwt.verify(verifier);

--- a/verifier-application/src/test/java/ch/admin/bj/swiyu/verifier/infrastructure/health/SigningKeyVerificationHealthCheckerTest.java
+++ b/verifier-application/src/test/java/ch/admin/bj/swiyu/verifier/infrastructure/health/SigningKeyVerificationHealthCheckerTest.java
@@ -87,7 +87,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.canProvideSigner()).thenReturn(true);
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(TEST_VERIFICATION_METHOD)).thenReturn(jwk);
-        when(jwk.toString()).thenReturn(testKey.toPublicJWK().toJSONString());
+        when(jwk.getKty()).thenReturn(testKey.getKeyType().toString());
+        when(jwk.getCrv()).thenReturn(testKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(testKey.getX().toString());
+        when(jwk.getY()).thenReturn(testKey.getY().toString());
+        when(jwk.getKid()).thenReturn(testKey.getKeyID());
         doNothing().when(didDoc).close();
 
         Health.Builder builder = Health.up();
@@ -185,7 +189,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.canProvideSigner()).thenReturn(true);
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(TEST_VERIFICATION_METHOD)).thenReturn(jwk);
-        when(jwk.toString()).thenReturn("invalid-json");
+        when(jwk.getKty()).thenReturn("invalid-kty");
+        when(jwk.getCrv()).thenReturn(testKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(testKey.getX().toString());
+        when(jwk.getY()).thenReturn(testKey.getY().toString());
+        when(jwk.getKid()).thenReturn(testKey.getKeyID());
 
         Health.Builder builder = Health.up();
 
@@ -208,7 +216,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.canProvideSigner()).thenReturn(true);
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(verificationMethodWithFragment)).thenReturn(jwk);
-        when(jwk.toString()).thenReturn(testKey.toPublicJWK().toJSONString());
+        when(jwk.getKty()).thenReturn(testKey.getKeyType().toString());
+        when(jwk.getCrv()).thenReturn(testKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(testKey.getX().toString());
+        when(jwk.getY()).thenReturn(testKey.getY().toString());
+        when(jwk.getKid()).thenReturn(testKey.getKeyID());
         doNothing().when(didDoc).close();
 
         Health.Builder builder = Health.up();
@@ -232,7 +244,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.canProvideSigner()).thenReturn(true);
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(verificationMethodWithoutFragment)).thenReturn(jwk);
-        when(jwk.toString()).thenReturn(testKey.toPublicJWK().toJSONString());
+        when(jwk.getKty()).thenReturn(testKey.getKeyType().toString());
+        when(jwk.getCrv()).thenReturn(testKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(testKey.getX().toString());
+        when(jwk.getY()).thenReturn(testKey.getY().toString());
+        when(jwk.getKid()).thenReturn(testKey.getKeyID());
         doNothing().when(didDoc).close();
 
         Health.Builder builder = Health.up();
@@ -260,7 +276,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(TEST_VERIFICATION_METHOD)).thenReturn(jwk);
         // Return a different public key for verification
-        when(jwk.toString()).thenReturn(differentKey.toPublicJWK().toJSONString());
+        when(jwk.getKty()).thenReturn(differentKey.getKeyType().toString());
+        when(jwk.getCrv()).thenReturn(differentKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(differentKey.getX().toString());
+        when(jwk.getY()).thenReturn(differentKey.getY().toString());
+        when(jwk.getKid()).thenReturn(differentKey.getKeyID());
         doNothing().when(didDoc).close();
 
         Health.Builder builder = Health.up();
@@ -285,7 +305,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.canProvideSigner()).thenReturn(true);
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(TEST_VERIFICATION_METHOD)).thenReturn(jwk);
-        when(jwk.toString()).thenReturn(testKey.toPublicJWK().toJSONString());
+        when(jwk.getKty()).thenReturn(testKey.getKeyType().toString());
+        when(jwk.getCrv()).thenReturn(testKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(testKey.getX().toString());
+        when(jwk.getY()).thenReturn(testKey.getY().toString());
+        when(jwk.getKid()).thenReturn(testKey.getKeyID());
         doNothing().when(didDoc).close();
 
         Health.Builder builder = Health.up();
@@ -306,7 +330,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.canProvideSigner()).thenReturn(true);
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(TEST_VERIFICATION_METHOD)).thenReturn(jwk);
-        when(jwk.toString()).thenReturn(testKey.toPublicJWK().toJSONString());
+        when(jwk.getKty()).thenReturn(testKey.getKeyType().toString());
+        when(jwk.getCrv()).thenReturn(testKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(testKey.getX().toString());
+        when(jwk.getY()).thenReturn(testKey.getY().toString());
+        when(jwk.getKid()).thenReturn(testKey.getKeyID());
         doNothing().when(didDoc).close();
 
         Health.Builder builder = Health.up();
@@ -326,7 +354,11 @@ class SigningKeyVerificationHealthCheckerTest {
         when(signerProvider.canProvideSigner()).thenReturn(true);
         when(signerProvider.getSigner()).thenReturn(testSigner);
         when(didDoc.getKey(TEST_VERIFICATION_METHOD)).thenReturn(jwk);
-        when(jwk.toString()).thenReturn(testKey.toPublicJWK().toJSONString());
+        when(jwk.getKty()).thenReturn(testKey.getKeyType().toString());
+        when(jwk.getCrv()).thenReturn(testKey.getCurve().getName());
+        when(jwk.getX()).thenReturn(testKey.getX().toString());
+        when(jwk.getY()).thenReturn(testKey.getY().toString());
+        when(jwk.getKid()).thenReturn(testKey.getKeyID());
         doNothing().when(didDoc).close();
 
         Health.Builder builder = Health.up();


### PR DESCRIPTION
Use map parsing because toString doesn’t return valid JSON