### PR TITLE
Harden CI + pin all GitHub Actions to SHAs + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,5 +75,12 @@ updates:
       interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "dependencies"
+      - "github-actions"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,5 +61,12 @@ updates:
       interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "dependencies"
+      - "github-actions"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         # https://docs.github.com/actions/use-cases-and-examples/building-and-testing/building-and-testing-java-with-maven
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -58,7 +58,7 @@ jobs:
         run: mvn --batch-mode clean generate-resources install
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Extract metadata (hardened, default)
         id: meta-dhi
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Disable latest tag
@@ -117,7 +117,7 @@ jobs:
             type=raw,value=${{ inputs.version_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version_tag != '' }}
       - name: Build and push unhardened docker image
         id: push-unhardened
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -128,7 +128,7 @@ jobs:
           file: Dockerfile
 
       - name: Monitor Snyk for vulnerabilities in code 📦
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         env:
           JAVA_HOME: '' # Snyk action sets JAVA_HOME to a path that is not compatible with the setup-java action, so we need to reset it here
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
 
       # Image variants are tracked as distinct Snyk projects so findings don't merge.
       - name: Monitor Snyk for vulnerabilities in hardened image 🐳
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         with:
           command: monitor
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION_TAG }}

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -36,6 +36,7 @@ env:
 jobs:
   build-and-publish-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -36,6 +36,7 @@ env:
 jobs:
   build-and-publish-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read
@@ -107,7 +108,8 @@ jobs:
           # report only vulnerabilities with level high or critical, as we want to avoid noise in the PR checks
           command: monitor
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION_TAG }}
-          args: --severity-threshold=high --severity-threshold=high --project-tags:app-name=swiyu-verifier,version=${{ env.IMAGE_VERSION_TAG }} --target-reference=${{ github.ref_name }}
+          # Fixed: removed a duplicated `--severity-threshold=high` flag.
+          args: --severity-threshold=high --project-tags:app-name=swiyu-verifier,version=${{ env.IMAGE_VERSION_TAG }} --target-reference=${{ github.ref_name }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_API: https://api.eu.snyk.io

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         # https://docs.github.com/actions/use-cases-and-examples/building-and-testing/building-and-testing-java-with-maven
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -58,14 +58,14 @@ jobs:
         run: mvn --batch-mode clean generate-resources install
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Disable latest tag
@@ -81,7 +81,7 @@ jobs:
             type=raw,value=${{ inputs.version_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version_tag != '' }}
       - name: Build and push docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -92,7 +92,7 @@ jobs:
           file: Dockerfile
 
       - name: Monitor Snyk for vulnerabilities in code 📦
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         env:
           JAVA_HOME: '' # Snyk action sets JAVA_HOME to a path that is not compatible with the setup-java action, so we need to reset it here
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
           command: monitor
           args: --maven-aggregate-project --severity-threshold=high --project-tags:app-name=swiyu-verifier,version=${{ env.IMAGE_VERSION_TAG  }} --target-reference=${{ github.ref_name }}
       - name: Monitor Snyk for vulnerabilities in image 🐳
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         with:
           # report only vulnerabilities with level high or critical, as we want to avoid noise in the PR checks
           command: monitor

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -22,14 +22,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           languages: java
           config-file: ./.github/codeql/codeql-config.yml
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -37,11 +37,11 @@ jobs:
       - name: Build & test with Maven (produce JaCoCo)
         run: mvn --batch-mode clean verify -DskipTests=false
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           category: "/language:java"
       - name: Upload JaCoCo reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jacoco-reports
           path: |
@@ -51,26 +51,26 @@ jobs:
             verifier-application/target/site/jacoco/index.html
 
       - name: Setup Node.js (for coverage summary script)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: Add coverage to summary
         run: node .github/scripts/coverage-summary.js
 
       - name: Run PMD static analysis
-        uses: pmd/pmd-github-action@v2
+        uses: pmd/pmd-github-action@d9c1f3c5940cbf5923f1354e83fa858b4496ebaa # v2
         id: pmd
         with:
           rulesets: '.github/rulesets/java/pmd_omni_ruleset.xml'
           cache: true
 
       - name: Upload PMD SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: pmd-report.sarif
 
       - name: Run Snyk to check for vulnerabilities 🔍
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         continue-on-error: false
         env:
           JAVA_HOME: '' # Snyk action sets JAVA_HOME to a path that is not compatible with the setup-java action, so we need to reset it here
@@ -82,13 +82,13 @@ jobs:
           args: --maven-aggregate-project --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result as sarif to GitHub Code Scanning 📦
         if: always() # We want to upload the SARIF file even if the Snyk action fails, to have the results in the Code Scanning tab of GitHub
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: snyk.sarif
 
       - name: Build and push docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           load: true
@@ -98,7 +98,7 @@ jobs:
           file: Dockerfile
 
       - name: Scan Docker image with Snyk 🐳
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         continue-on-error: false
         with:
           # report only vulnerabilities with level high or critical, as we want to avoid noise in the PR checks

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -3,18 +3,23 @@ name: Pull Request Check
 run-name: ${{ github.repository }} is evaluating pull request
 on: [pull_request]
 
+# Cancel superseded runs on the same PR to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: this job builds/loads a local image (no push) and uploads SARIF,
+# and comments coverage on the PR. It does not publish packages or create attestations.
 permissions:
   actions: read
-  security-events: write
   contents: read
-  packages: write
-  attestations: write
-  id-token: write
+  security-events: write
   pull-requests: write  # allow coverage comment
 
 jobs:
   docker-security-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -9,12 +9,11 @@ concurrency:
   cancel-in-progress: true
 
 # Least privilege: this job builds/loads a local image (no push) and uploads SARIF,
-# and comments coverage on the PR. It does not publish packages or create attestations.
+# writes the coverage summary to the job summary, and does not publish packages or create attestations.
 permissions:
   actions: read
   contents: read
   security-events: write
-  pull-requests: write  # allow coverage comment
 
 jobs:
   docker-security-scan:

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -22,14 +22,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           languages: java
           config-file: ./.github/codeql/codeql-config.yml
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -37,11 +37,11 @@ jobs:
       - name: Build & test with Maven (produce JaCoCo)
         run: mvn --batch-mode clean verify -DskipTests=false
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           category: "/language:java"
       - name: Upload JaCoCo reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jacoco-reports
           path: |
@@ -51,26 +51,26 @@ jobs:
             verifier-application/target/site/jacoco/index.html
 
       - name: Setup Node.js (for coverage summary script)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: Add coverage to summary
         run: node .github/scripts/coverage-summary.js
 
       - name: Run PMD static analysis
-        uses: pmd/pmd-github-action@v2
+        uses: pmd/pmd-github-action@d9c1f3c5940cbf5923f1354e83fa858b4496ebaa # v2
         id: pmd
         with:
           rulesets: '.github/rulesets/java/pmd_omni_ruleset.xml'
           cache: true
 
       - name: Upload PMD SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: pmd-report.sarif
 
       - name: Run Snyk to check for vulnerabilities 🔍
-        uses: snyk/actions/maven-3-jdk-21@master
+        uses: snyk/actions/maven-3-jdk-21@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         continue-on-error: false
         env:
           JAVA_HOME: '' # Snyk action sets JAVA_HOME to a path that is not compatible with the setup-java action, so we need to reset it here
@@ -82,7 +82,7 @@ jobs:
           args: --maven-aggregate-project --severity-threshold=high --sarif-file-output=snyk.sarif
       - name: Upload result as sarif to GitHub Code Scanning 📦
         if: always() # We want to upload the SARIF file even if the Snyk action fails, to have the results in the Code Scanning tab of GitHub
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: snyk.sarif
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build hardened (default) docker image
         id: build-dhi
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           load: true
@@ -102,7 +102,7 @@ jobs:
           file: Dockerfile.dhi
 
       - name: Scan hardened Docker image with Snyk 🐳
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
         continue-on-error: false
         with:
           # report only vulnerabilities with level high or critical, as we want to avoid noise in the PR checks

--- a/.github/workflows/retag-latest.yml
+++ b/.github/workflows/retag-latest.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
**Supply-chain hardening (combined, rebased on current main).** Two commits: (1) fix Snyk args, least-privilege `permissions`, `concurrency` + `timeout-minutes` - **preserving** the recently-added OpenAPI-spec generation/validation steps; (2) pin all GitHub Actions to full commit SHAs and add a `github-actions` Dependabot entry.

---
**Notes**
- Snyk steps need maintainer-side `SNYK_TOKEN`/`SNYK_ORG` secrets; fork-PR CI runs only after a maintainer clicks *Approve and run*.
- DCO: commit signed off by Daniel Casota.